### PR TITLE
Service for pairwise similarity of list of ontology classes

### DIFF
--- a/src/main/scala/org/phenoscape/kb/Main.scala
+++ b/src/main/scala/org/phenoscape/kb/Main.scala
@@ -42,6 +42,7 @@ object Main extends HttpApp with App {
   JenaSystem.init()
 
   implicit val system = ActorSystem("phenoscape-kb-system")
+
   import system.dispatcher
 
   val factory = OWLManager.getOWLDataFactory
@@ -83,596 +84,595 @@ object Main extends HttpApp with App {
 
   def routes: Route = cors() {
     alwaysCache(memoryCache, cacheKeyer) {
-      respondWithHeaders(
-        RawHeader("Vary", "negotiate, Accept")) {
-          pathSingleSlash {
-            redirect(Uri("http://kb.phenoscape.org/apidocs/"), StatusCodes.SeeOther)
-          } ~ pathPrefix("kb") {
-            path("annotation_summary") {
+      respondWithHeaders(RawHeader("Vary", "negotiate, Accept")) {
+        pathSingleSlash {
+          redirect(Uri("http://kb.phenoscape.org/apidocs/"), StatusCodes.SeeOther)
+        } ~ pathPrefix("kb") {
+          path("annotation_summary") {
+            complete {
+              KB.annotationSummary
+            }
+          } ~
+            path("annotation_report") {
               complete {
-                KB.annotationSummary
+                KB.annotationReport
               }
-            } ~
-              path("annotation_report") {
+            }
+        } ~
+          pathPrefix("term") {
+            path("search") {
+              parameters('text, 'type.as[IRI].?(owlClass), 'property.?(rdfsLabel)) { (text, termType, property) =>
                 complete {
-                  KB.annotationReport
+                  import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                  Term.search(text, termType, property)
                 }
               }
-          } ~
-            pathPrefix("term") {
-              path("search") {
-                parameters('text, 'type.as[IRI].?(owlClass), 'property.?(rdfsLabel)) { (text, termType, property) =>
+            } ~
+              path("search_classes") {
+                parameters('text, 'definedBy.as[IRI], 'limit.as[Int].?(0)) { (text, definedBy, limit) =>
                   complete {
                     import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                    Term.search(text, termType, property)
+                    Term.searchOntologyTerms(text, definedBy, limit)
                   }
                 }
               } ~
-                path("search_classes") {
-                  parameters('text, 'definedBy.as[IRI], 'limit.as[Int].?(0)) { (text, definedBy, limit) =>
+              path("label") {
+                parameters('iri.as[IRI]) { (iri) =>
+                  complete {
+                    Term.computedLabel(iri)
+                  }
+                }
+              } ~
+              path("labels") {
+                parameters('iris.as[Seq[IRI]]) { (iris) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    Term.labels(iris: _*)
+                  }
+                }
+              } ~
+              path("classification") {
+                parameters('iri.as[IRI], 'definedBy.as[IRI].?) { (iri, source) =>
+                  complete {
+                    Term.classification(iri, source)
+                  }
+                }
+              } ~
+              path("least_common_subsumers") {
+                parameters('iris.as[Seq[IRI]], 'definedBy.as[IRI].?) { (iris, source) =>
+                  complete {
+                    Term.leastCommonSubsumers(iris, source)
+                  }
+                }
+              } ~
+              path("all_ancestors") {
+                parameters('iri.as[IRI]) { (iri) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    Term.allAncestors(iri)
+                  }
+                }
+              } ~
+              path("all_descendants") {
+                parameters('iri.as[IRI]) { (iri) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    Term.allDescendants(iri)
+                  }
+                }
+              } ~
+              pathPrefix("property_neighbors") {
+                path("object") {
+                  parameters('term.as[IRI], 'property.as[IRI]) { (term, property) =>
                     complete {
                       import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      Term.searchOntologyTerms(text, definedBy, limit)
+                      Graph.propertyNeighborsForObject(term, property)
                     }
                   }
                 } ~
-                path("label") {
-                  parameters('iri.as[IRI]) { (iri) =>
-                    complete {
-                      Term.computedLabel(iri)
-                    }
-                  }
-                } ~
-                path("labels") {
-                  parameters('iris.as[Seq[IRI]]) { (iris) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      Term.labels(iris: _*)
-                    }
-                  }
-                } ~
-                path("classification") {
-                  parameters('iri.as[IRI], 'definedBy.as[IRI].?) { (iri, source) =>
-                    complete {
-                      Term.classification(iri, source)
-                    }
-                  }
-                } ~
-                path("least_common_subsumers") {
-                  parameters('iris.as[Seq[IRI]], 'definedBy.as[IRI].?) { (iris, source) =>
-                    complete {
-                      Term.leastCommonSubsumers(iris, source)
-                    }
-                  }
-                } ~
-                path("all_ancestors") {
-                  parameters('iri.as[IRI]) { (iri) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      Term.allAncestors(iri)
-                    }
-                  }
-                } ~
-                path("all_descendants") {
-                  parameters('iri.as[IRI]) { (iri) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      Term.allDescendants(iri)
-                    }
-                  }
-                } ~
-                pathPrefix("property_neighbors") {
-                  path("object") {
+                  path("subject") {
                     parameters('term.as[IRI], 'property.as[IRI]) { (term, property) =>
                       complete {
                         import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                        Graph.propertyNeighborsForObject(term, property)
-                      }
-                    }
-                  } ~
-                    path("subject") {
-                      parameters('term.as[IRI], 'property.as[IRI]) { (term, property) =>
-                        complete {
-                          import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                          Graph.propertyNeighborsForSubject(term, property)
-                        }
-                      }
-                    }
-                } ~
-                path("resolve_label_expression") {
-                  parameters('expression) { (expression) =>
-                    complete {
-                      Term.resolveLabelExpression(expression) match {
-                        case Success(expression) => expression
-                        case Failure(error)      => StatusCodes.UnprocessableEntity -> error
+                        Graph.propertyNeighborsForSubject(term, property)
                       }
                     }
                   }
-                } ~
-                pathEnd {
-                  parameters('iri.as[IRI]) { iri =>
-                    complete {
-                      Term.withIRI(iri)
+              } ~
+              path("resolve_label_expression") {
+                parameters('expression) { (expression) =>
+                  complete {
+                    Term.resolveLabelExpression(expression) match {
+                      case Success(expression) => expression
+                      case Failure(error)      => StatusCodes.UnprocessableEntity -> error
                     }
                   }
                 }
-            } ~
-            path("ontotrace") {
-              parameters('entity.as[OWLClassExpression], 'taxon.as[OWLClassExpression], 'variable_only.as[Boolean].?(true), 'parts.as[Boolean].?(false)) { (entity, taxon, variableOnly, includeParts) =>
-                respondWithHeader(headers.`Content-Disposition`(ContentDispositionTypes.attachment, Map("filename" -> "ontotrace.xml"))) {
+              } ~
+              pathEnd {
+                parameters('iri.as[IRI]) { iri =>
                   complete {
-                    PresenceAbsenceOfStructure.presenceAbsenceMatrix(entity, taxon, variableOnly, includeParts)
+                    Term.withIRI(iri)
                   }
                 }
               }
-            } ~
-            pathPrefix("similarity") {
-              path("query") {
-                parameters('iri.as[IRI], 'corpus_graph.as[IRI], 'limit.as[Int].?(20), 'offset.as[Int].?(0)) { (query, corpusGraph, limit, offset) =>
-                  complete {
-                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                    Similarity.querySimilarProfiles(query, corpusGraph, limit, offset)
-                  }
-                }
-              } ~ // why 2 graphs??
-                path("best_matches") {
-                  parameters('query_iri.as[IRI], 'corpus_iri.as[IRI], 'query_graph.as[IRI], 'corpus_graph.as[IRI]) { (queryItem, corpusItem, queryGraph, corpusGraph) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      Similarity.bestAnnotationsMatchesForComparison(queryItem, queryGraph, corpusItem, corpusGraph)
-                    }
-                  }
-                } ~
-                path("best_subsumers") {
-                  parameters('query_iri.as[IRI], 'corpus_iri.as[IRI], 'corpus_graph.as[IRI]) { (queryItem, corpusItem, corpusGraph) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      Similarity.bestSubsumersForComparison(queryItem, corpusItem, corpusGraph)
-                    }
-                  }
-                } ~
-                path("subsumed_annotations") {
-                  parameters('subsumer.as[OWLClass], 'instance.as[OWLNamedIndividual]) { (subsumer, instance) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      Similarity.subsumedAnnotations(instance, subsumer)
-                    }
-                  }
-                } ~
-                path("profile_size") {
-                  parameters('iri.as[IRI]) { (iri) =>
-                    complete {
-                      Similarity.profileSize(iri).map(ResultCount(_))
-                    }
-                  }
-                } ~
-                path("corpus_size") {
-                  parameters('corpus_graph.as[IRI]) { (corpusGraph) =>
-                    complete {
-                      Similarity.corpusSize(corpusGraph).map(ResultCount(_))
-                    }
-                  }
-                } ~
-                path("ic_disparity") {
-                  parameters('iri.as[OWLClass], 'queryGraph.as[IRI], 'corpus_graph.as[IRI]) { (term, queryGraph, corpusGraph) =>
-                    complete {
-                      Similarity.icDisparity(term, queryGraph, corpusGraph).map(value => JsObject("value" -> value.toJson))
-                    }
-                  }
-                } ~
-                path("states") {
-                  parameters('leftStudy.as[IRI], 'leftCharacter.as[Int], 'leftSymbol, 'rightStudy.as[IRI], 'rightCharacter.as[Int], 'rightSymbol) { (leftStudyIRI, leftCharacterNum, leftSymbol, rightStudyIRI, rightCharacterNum, rightSymbol) =>
-                    complete {
-                      Similarity.stateSimilarity(leftStudyIRI, leftCharacterNum, leftSymbol, rightStudyIRI, rightCharacterNum, rightSymbol).map(_.toJson)
-                    }
-                  }
-                }
-            } ~
-            pathPrefix("characterstate") {
-              path("search") { //undocumented and currently unused
-                parameters('text, 'limit.as[Int]) { (text, limit) =>
-                  complete {
-                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                    CharacterDescription.search(text, limit)
-                  }
-                }
-              } ~
-                path("query") { //undocumented and currently unused
-                  parameters('entity.as[OWLClassExpression].?(owlThing: OWLClassExpression), 'taxon.as[OWLClassExpression].?(owlThing: OWLClassExpression), 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (entity, taxon, limit, offset, total) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      if (total) CharacterDescription.queryTotal(entity, taxon, Nil)
-                      else CharacterDescription.query(entity, taxon, Nil, limit, offset)
-                    }
-                  }
-                } ~
-                path("with_annotation") { //undocumented and currently unused
-                  parameter('iri.as[IRI]) { iri =>
-                    complete {
-                      CharacterDescription.annotatedCharacterDescriptionWithAnnotation(iri)
-                    }
-                  }
-                }
-            } ~
-            pathPrefix("taxon") {
-              path("phenotypes") {
-                parameters('taxon.as[IRI], 'entity.as[OWLClassExpression].?, 'quality.as[OWLClassExpression].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false), 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) {
-                  (taxon, entityOpt, qualityOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset, total) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      if (total) Taxon.directPhenotypesTotalFor(taxon, entityOpt, qualityOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs).map(ResultCount(_))
-                      else Taxon.directPhenotypesFor(taxon, entityOpt, qualityOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset)
-                    }
-                }
-              } ~
-                path("variation_profile") {
-                  parameters('taxon.as[IRI], 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (taxon, limit, offset, total) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      if (total) Taxon.variationProfileTotalFor(taxon).map(ResultCount(_))
-                      else Taxon.variationProfileFor(taxon, limit, offset)
-                    }
-                  }
-                } ~
-                path("with_phenotype") {
-                  parameters('entity.as[OWLClassExpression].?(owlThing: OWLClassExpression), 'quality.as[OWLClassExpression].?(owlThing: OWLClassExpression), 'in_taxon.as[IRI].?, 'publication.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false), 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) {
-                    (entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset, total) =>
-                      complete {
-                        import org.phenoscape.kb.Taxon.ComboTaxaMarshaller
-                        if (total) {
-                          Taxon.withPhenotypeTotal(entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs).map(ResultCount(_))
-                        } else Taxon.withPhenotype(entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset)
-                      }
-                  }
-                } ~
-                path("facet" / "phenotype" / Segment) { facetBy =>
-                  parameters('entity.as[IRI].?, 'quality.as[IRI].?, 'in_taxon.as[IRI].?, 'publication.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false)) {
-                    (entityOpt, qualityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs) =>
-                      complete {
-                        facetBy match {
-                          case "entity"  => Taxon.facetTaxaWithPhenotypeByEntity(entityOpt, qualityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
-                          case "quality" => Taxon.facetTaxaWithPhenotypeByQuality(qualityOpt, entityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
-                          case "taxon"   => Taxon.facetTaxaWithPhenotypeByTaxon(taxonOpt, entityOpt, qualityOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
-                        }
-                      }
-                  }
-                } ~
-                path("facet" / "annotations" / Segment) { facetBy =>
-                  parameters('entity.as[IRI].?, 'quality.as[IRI].?, 'in_taxon.as[IRI].?, 'publication.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false)) {
-                    (entityOpt, qualityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs) =>
-                      complete {
-                        facetBy match {
-                          case "entity"  => TaxonPhenotypeAnnotation.facetTaxonAnnotationsByEntity(entityOpt, qualityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
-                          case "quality" => TaxonPhenotypeAnnotation.facetTaxonAnnotationsByQuality(qualityOpt, entityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
-                          case "taxon"   => TaxonPhenotypeAnnotation.facetTaxonAnnotationsByTaxon(taxonOpt, entityOpt, qualityOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
-                        }
-                      }
-                  }
-                } ~
-                path("annotations") { //FIXME needs documentation
-                  parameters('entity.as[IRI].?, 'quality.as[IRI].?, 'in_taxon.as[IRI].?, 'publication.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false), 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) {
-                    (entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset, total) =>
-                      complete {
-                        if (total) TaxonPhenotypeAnnotation.queryAnnotationsTotal(entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs).map(ResultCount(_))
-                        else TaxonPhenotypeAnnotation.queryAnnotations(entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset)
-                      }
-                  }
-                } ~
-                path("annotation" / "sources") { //FIXME needs documentation
-                  parameters('taxon.as[IRI], 'phenotype.as[IRI]) {
-                    (taxon, phenotype) =>
-                      complete {
-                        import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                        TaxonPhenotypeAnnotation.annotationSources(taxon, phenotype)
-                      }
-                  }
-                } ~
-                path("with_rank") {
-                  parameters('rank.as[IRI], 'in_taxon.as[IRI]) { (rank, inTaxon) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      Taxon.taxaWithRank(rank, inTaxon)
-                    }
-                  }
-                } ~
-                path("annotated_taxa_count") {
-                  parameter('in_taxon.as[IRI]) { inTaxon =>
-                    complete {
-                      Taxon.countOfAnnotatedTaxa(inTaxon).map(ResultCount(_))
-                    }
-                  }
-                } ~
-                path("newick") {
-                  parameters('iri.as[IRI]) { (taxon) =>
-                    complete {
-                      Taxon.newickTreeWithRoot(taxon)
-                    }
-                  }
-                } ~
-                path("group") {
-                  parameters('iri.as[IRI]) { (taxon) =>
-                    complete {
-                      Taxon.commonGroupFor(taxon)
-                    }
-                  }
-                } ~
-                pathEnd {
-                  parameters('iri.as[IRI]) { iri =>
-                    complete {
-                      Taxon.withIRI(iri)
-                    }
-                  }
-                }
-            } ~
-            pathPrefix("entity") {
-              path("search") {
-                parameters('text, 'limit.as[Int].?(20)) { (text, limit) =>
-                  complete {
-                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                    Term.searchOntologyTerms(text, Uberon, limit)
-                  }
-                }
-              } ~
-                pathPrefix("absence") {
-                  path("evidence") {
-                    parameters('taxon.as[IRI], 'entity.as[IRI], 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (taxon, entity, limit, offset, totalOnly) =>
-                      complete {
-                        import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                        if (totalOnly) PresenceAbsenceOfStructure.statesEntailingAbsenceTotal(taxon, entity).map(ResultCount(_))
-                        else PresenceAbsenceOfStructure.statesEntailingAbsence(taxon, entity, limit, offset)
-                      }
-                    }
-                  } ~
-                    pathEnd {
-                      parameters('entity.as[IRI], 'in_taxon.as[IRI].?, 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (entity, taxonFilter, limit, offset, totalOnly) =>
-                        complete {
-                          if (totalOnly) PresenceAbsenceOfStructure.taxaExhibitingAbsenceTotal(entity, taxonFilter).map(ResultCount(_))
-                          else PresenceAbsenceOfStructure.taxaExhibitingAbsence(entity, taxonFilter, limit = limit, offset = offset)
-                        }
-                      }
-                    }
-
-                } ~
-                pathPrefix("presence") {
-                  path("evidence") {
-                    parameters('taxon.as[IRI], 'entity.as[IRI], 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (taxon, entity, limit, offset, totalOnly) =>
-                      complete {
-                        import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                        if (totalOnly) PresenceAbsenceOfStructure.statesEntailingPresenceTotal(taxon, entity).map(ResultCount(_))
-                        else PresenceAbsenceOfStructure.statesEntailingPresence(taxon, entity, limit, offset)
-                      }
-                    }
-                  } ~
-                    pathEnd {
-                      parameters('entity.as[IRI], 'in_taxon.as[IRI].?, 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (entity, taxonFilter, limit, offset, totalOnly) =>
-                        complete {
-                          if (totalOnly) PresenceAbsenceOfStructure.taxaExhibitingPresenceTotal(entity, taxonFilter).map(ResultCount(_))
-                          else PresenceAbsenceOfStructure.taxaExhibitingPresence(entity, taxonFilter, limit = limit, offset = offset)
-                        }
-                      }
-                    }
-                } ~
-                path("homology") {
-                  parameters('entity.as[IRI]) { (entity) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      AnatomicalEntity.homologyAnnotations(entity, false)
-                    }
-                  }
-                }
-            } ~
-            pathPrefix("gene") {
-              path("search") {
-                parameters('text, 'taxon.as[IRI].?) { (text, taxonOpt) =>
-                  complete {
-                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                    Gene.search(text, taxonOpt)
-                  }
-                }
-              } ~
-                path("eq") {
-                  parameters('id.as[IRI]) { iri =>
-                    complete {
-                      EQForGene.query(iri)
-                    }
-                  }
-                } ~
-                path("phenotype_annotations") { // undocumented and not currently used
-                  parameters('entity.as[OWLClassExpression].?, 'quality.as[OWLClassExpression].?, 'in_taxon.as[IRI].?, 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) {
-                    (entity, quality, taxonOpt, limit, offset, total) =>
-                      complete {
-                        if (total) GenePhenotypeAnnotation.queryAnnotationsTotal(entity, quality, taxonOpt).map(ResultCount(_))
-                        else GenePhenotypeAnnotation.queryAnnotations(entity, quality, taxonOpt, limit, offset)
-                      }
-                  }
-                } ~
-                path("expression_annotations") { // undocumented and not currently used
-                  parameters('entity.as[OWLClassExpression].?, 'in_taxon.as[IRI].?, 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) {
-                    (entity, taxonOpt, limit, offset, total) =>
-                      complete {
-                        import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                        if (total) GeneExpressionAnnotation.queryAnnotationsTotal(entity, taxonOpt).map(ResultCount(_))
-                        else GeneExpressionAnnotation.queryAnnotations(entity, taxonOpt, limit, offset)
-                      }
-                  }
-                } ~
-                path("query") { // undocumented and not currently used
-                  parameters('entity.as[OWLClassExpression].?(owlThing: OWLClassExpression), 'taxon.as[OWLClassExpression].?(owlThing: OWLClassExpression), 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (entity, taxon, limit, offset, total) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      if (total) Gene.queryTotal(entity, taxon)
-                      else Gene.query(entity, taxon, limit, offset)
-                    }
-                  }
-                } ~
-                path("phenotypic_profile") {
-                  parameters('iri.as[IRI]) { (iri) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      Gene.phenotypicProfile(iri)
-                    }
-                  }
-                } ~
-                path("expression_profile") {
-                  parameters('iri.as[IRI]) { (iri) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      Gene.expressionProfile(iri)
-                    }
-                  }
-                } ~
-                path("affecting_entity_phenotype") {
-                  //TODO update documentation that iri is optional
-                  parameters('iri.as[IRI].?, 'quality.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false), 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) {
-                    (iri, quality, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset, total) =>
-                      complete {
-                        import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                        if (total) Gene.affectingPhenotypeOfEntityTotal(iri, quality, includeParts, includeHistoricalHomologs, includeSerialHomologs).map(ResultCount(_))
-                        else Gene.affectingPhenotypeOfEntity(iri, quality, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset)
-                      }
-                  }
-                } ~
-                path("expressed_within_entity") {
-                  parameters('iri.as[IRI], 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (iri, limit, offset, total) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      if (total) Gene.expressedWithinEntityTotal(iri).map(ResultCount(_))
-                      else Gene.expressedWithinEntity(iri, limit, offset)
-                    }
-                  }
-                } ~
-                path("facet" / "phenotype" / Segment) { facetBy =>
-                  parameters('entity.as[IRI].?, 'quality.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false)) {
-                    (entityOpt, qualityOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs) =>
-                      complete {
-                        facetBy match {
-                          case "entity"  => Gene.facetGenesWithPhenotypeByEntity(entityOpt, qualityOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
-                          case "quality" => Gene.facetGenesWithPhenotypeByQuality(qualityOpt, entityOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
-                        }
-                      }
-                  }
-                } ~
-                pathEnd {
-                  parameters('iri.as[IRI]) { iri =>
-                    complete {
-                      Gene.withIRI(iri)
-                    }
-                  }
-                }
-            } ~
-            pathPrefix("study") {
-              path("query") { //FIXME doc out of date
-                parameters('entity.as[IRI].?, 'quality.as[IRI].?, 'in_taxon.as[IRI].?, 'publication.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false), 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) {
-                  (entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset, total) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      if (total) Study.queryStudiesTotal(entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs).map(ResultCount(_))
-                      else Study.queryStudies(entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset)
-                    }
-                }
-              } ~
-                path("facet" / Segment) { facetBy =>
-                  parameters('entity.as[IRI].?, 'quality.as[IRI].?, 'in_taxon.as[IRI].?, 'publication.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false)) {
-                    (entityOpt, qualityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs) =>
-                      complete {
-                        facetBy match {
-                          case "entity"  => Study.facetStudiesByEntity(entityOpt, qualityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
-                          case "quality" => Study.facetStudiesByQuality(qualityOpt, entityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
-                          case "taxon"   => Study.facetStudiesByTaxon(taxonOpt, entityOpt, qualityOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
-                        }
-                      }
-                  }
-                } ~
-                path("taxa") {
-                  parameters('iri.as[IRI], 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (studyIRI, limit, offset, total) =>
-                    complete {
-                      if (total) Study.annotatedTaxaTotal(studyIRI).map(ResultCount(_))
-                      else Study.annotatedTaxa(studyIRI, limit, offset)
-                    }
-                  }
-                } ~
-                path("phenotypes") {
-                  parameters('iri.as[IRI], 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (studyIRI, limit, offset, total) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      if (total) Study.annotatedPhenotypesTotal(studyIRI).map(ResultCount(_))
-                      else Study.annotatedPhenotypes(studyIRI, limit, offset)
-                    }
-                  }
-                } ~
-                path("matrix") {
-                  parameters('iri.as[IRI]) { (iri) =>
-                    complete {
-                      val prettyPrinter = new scala.xml.PrettyPrinter(9999, 2)
-                      Study.queryMatrix(iri).map(prettyPrinter.format(_))
-                    }
-                  }
-                } ~
-                pathEnd {
-                  parameters('iri.as[IRI]) { iri =>
-                    complete {
-                      Study.withIRI(iri)
-                    }
-                  }
-                }
-            } ~
-            pathPrefix("phenotype") {
-              path("query") {
-                parameters('entity.as[IRI].?, 'quality.as[IRI].?, 'in_taxon.as[IRI].?, 'publication.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false), 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) {
-                  (entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset, total) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      if (total) Phenotype.queryTaxonPhenotypesTotal(entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs).map(ResultCount(_))
-                      else Phenotype.queryTaxonPhenotypes(entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset)
-                    }
-                }
-              } ~
-                path("facet" / Segment) { facetBy =>
-                  parameters('entity.as[IRI].?, 'quality.as[IRI].?, 'in_taxon.as[IRI].?, 'publication.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false)) {
-                    (entityOpt, qualityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs) =>
-                      complete {
-                        facetBy match {
-                          case "entity"  => Phenotype.facetPhenotypeByEntity(entityOpt, qualityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
-                          case "quality" => Phenotype.facetPhenotypeByQuality(qualityOpt, entityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
-                          case "taxon"   => Phenotype.facetPhenotypeByTaxon(taxonOpt, entityOpt, qualityOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
-                        }
-                      }
-                  }
-                } ~
-                path("direct_annotations") { // undocumented and not currently used //FIXME actually this is used in a popup in web UI
-                  parameters('iri.as[IRI]) { (iri) =>
-                    complete {
-                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
-                      CharacterDescription.eqAnnotationsForPhenotype(iri)
-                    }
-                  }
-                } ~
-                path("nearest_eq") { // undocumented and not currently used
-                  parameters('iri.as[IRI]) { (iri) =>
-                    complete {
-                      Phenotype.eqForPhenotype(iri)
-                    }
-                  }
-                }
-            } ~
-            pathPrefix("report") {
-              path("data_coverage_figure") { // undocumented and not currently used
+          } ~
+          path("ontotrace") {
+            parameters('entity.as[OWLClassExpression], 'taxon.as[OWLClassExpression], 'variable_only.as[Boolean].?(true), 'parts.as[Boolean].?(false)) { (entity, taxon, variableOnly, includeParts) =>
+              respondWithHeader(headers.`Content-Disposition`(ContentDispositionTypes.attachment, Map("filename" -> "ontotrace.xml"))) {
                 complete {
-                  DataCoverageFigureReport.query()
+                  PresenceAbsenceOfStructure.presenceAbsenceMatrix(entity, taxon, variableOnly, includeParts)
+                }
+              }
+            }
+          } ~
+          pathPrefix("similarity") {
+            path("query") {
+              parameters('iri.as[IRI], 'corpus_graph.as[IRI], 'limit.as[Int].?(20), 'offset.as[Int].?(0)) { (query, corpusGraph, limit, offset) =>
+                complete {
+                  import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                  Similarity.querySimilarProfiles(query, corpusGraph, limit, offset)
+                }
+              }
+            } ~ // why 2 graphs??
+              path("best_matches") {
+                parameters('query_iri.as[IRI], 'corpus_iri.as[IRI], 'query_graph.as[IRI], 'corpus_graph.as[IRI]) { (queryItem, corpusItem, queryGraph, corpusGraph) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    Similarity.bestAnnotationsMatchesForComparison(queryItem, queryGraph, corpusItem, corpusGraph)
+                  }
                 }
               } ~
-                path("data_coverage_figure_catfish") { // undocumented and not currently used
+              path("best_subsumers") {
+                parameters('query_iri.as[IRI], 'corpus_iri.as[IRI], 'corpus_graph.as[IRI]) { (queryItem, corpusItem, corpusGraph) =>
                   complete {
-                    DataCoverageFigureReportCatfish.query()
-                  }
-                } ~
-                path("data_coverage_figure_any_taxon") { // undocumented and not currently used
-                  complete {
-                    DataCoverageFigureReportAnyTaxon.query()
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    Similarity.bestSubsumersForComparison(queryItem, corpusItem, corpusGraph)
                   }
                 }
-            }
-        }
+              } ~
+              path("subsumed_annotations") {
+                parameters('subsumer.as[OWLClass], 'instance.as[OWLNamedIndividual]) { (subsumer, instance) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    Similarity.subsumedAnnotations(instance, subsumer)
+                  }
+                }
+              } ~
+              path("profile_size") {
+                parameters('iri.as[IRI]) { (iri) =>
+                  complete {
+                    Similarity.profileSize(iri).map(ResultCount(_))
+                  }
+                }
+              } ~
+              path("corpus_size") {
+                parameters('corpus_graph.as[IRI]) { (corpusGraph) =>
+                  complete {
+                    Similarity.corpusSize(corpusGraph).map(ResultCount(_))
+                  }
+                }
+              } ~
+              path("ic_disparity") {
+                parameters('iri.as[OWLClass], 'queryGraph.as[IRI], 'corpus_graph.as[IRI]) { (term, queryGraph, corpusGraph) =>
+                  complete {
+                    Similarity.icDisparity(term, queryGraph, corpusGraph).map(value => JsObject("value" -> value.toJson))
+                  }
+                }
+              } ~
+              path("states") {
+                parameters('leftStudy.as[IRI], 'leftCharacter.as[Int], 'leftSymbol, 'rightStudy.as[IRI], 'rightCharacter.as[Int], 'rightSymbol) { (leftStudyIRI, leftCharacterNum, leftSymbol, rightStudyIRI, rightCharacterNum, rightSymbol) =>
+                  complete {
+                    Similarity.stateSimilarity(leftStudyIRI, leftCharacterNum, leftSymbol, rightStudyIRI, rightCharacterNum, rightSymbol).map(_.toJson)
+                  }
+                }
+              }
+          } ~
+          pathPrefix("characterstate") {
+            path("search") { //undocumented and currently unused
+              parameters('text, 'limit.as[Int]) { (text, limit) =>
+                complete {
+                  import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                  CharacterDescription.search(text, limit)
+                }
+              }
+            } ~
+              path("query") { //undocumented and currently unused
+                parameters('entity.as[OWLClassExpression].?(owlThing: OWLClassExpression), 'taxon.as[OWLClassExpression].?(owlThing: OWLClassExpression), 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (entity, taxon, limit, offset, total) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    if (total) CharacterDescription.queryTotal(entity, taxon, Nil)
+                    else CharacterDescription.query(entity, taxon, Nil, limit, offset)
+                  }
+                }
+              } ~
+              path("with_annotation") { //undocumented and currently unused
+                parameter('iri.as[IRI]) { iri =>
+                  complete {
+                    CharacterDescription.annotatedCharacterDescriptionWithAnnotation(iri)
+                  }
+                }
+              }
+          } ~
+          pathPrefix("taxon") {
+            path("phenotypes") {
+              parameters('taxon.as[IRI], 'entity.as[OWLClassExpression].?, 'quality.as[OWLClassExpression].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false), 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) {
+                (taxon, entityOpt, qualityOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset, total) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    if (total) Taxon.directPhenotypesTotalFor(taxon, entityOpt, qualityOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs).map(ResultCount(_))
+                    else Taxon.directPhenotypesFor(taxon, entityOpt, qualityOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset)
+                  }
+              }
+            } ~
+              path("variation_profile") {
+                parameters('taxon.as[IRI], 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (taxon, limit, offset, total) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    if (total) Taxon.variationProfileTotalFor(taxon).map(ResultCount(_))
+                    else Taxon.variationProfileFor(taxon, limit, offset)
+                  }
+                }
+              } ~
+              path("with_phenotype") {
+                parameters('entity.as[OWLClassExpression].?(owlThing: OWLClassExpression), 'quality.as[OWLClassExpression].?(owlThing: OWLClassExpression), 'in_taxon.as[IRI].?, 'publication.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false), 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) {
+                  (entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset, total) =>
+                    complete {
+                      import org.phenoscape.kb.Taxon.ComboTaxaMarshaller
+                      if (total) {
+                        Taxon.withPhenotypeTotal(entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs).map(ResultCount(_))
+                      } else Taxon.withPhenotype(entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset)
+                    }
+                }
+              } ~
+              path("facet" / "phenotype" / Segment) { facetBy =>
+                parameters('entity.as[IRI].?, 'quality.as[IRI].?, 'in_taxon.as[IRI].?, 'publication.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false)) {
+                  (entityOpt, qualityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs) =>
+                    complete {
+                      facetBy match {
+                        case "entity"  => Taxon.facetTaxaWithPhenotypeByEntity(entityOpt, qualityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+                        case "quality" => Taxon.facetTaxaWithPhenotypeByQuality(qualityOpt, entityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+                        case "taxon"   => Taxon.facetTaxaWithPhenotypeByTaxon(taxonOpt, entityOpt, qualityOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+                      }
+                    }
+                }
+              } ~
+              path("facet" / "annotations" / Segment) { facetBy =>
+                parameters('entity.as[IRI].?, 'quality.as[IRI].?, 'in_taxon.as[IRI].?, 'publication.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false)) {
+                  (entityOpt, qualityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs) =>
+                    complete {
+                      facetBy match {
+                        case "entity"  => TaxonPhenotypeAnnotation.facetTaxonAnnotationsByEntity(entityOpt, qualityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+                        case "quality" => TaxonPhenotypeAnnotation.facetTaxonAnnotationsByQuality(qualityOpt, entityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+                        case "taxon"   => TaxonPhenotypeAnnotation.facetTaxonAnnotationsByTaxon(taxonOpt, entityOpt, qualityOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+                      }
+                    }
+                }
+              } ~
+              path("annotations") { //FIXME needs documentation
+                parameters('entity.as[IRI].?, 'quality.as[IRI].?, 'in_taxon.as[IRI].?, 'publication.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false), 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) {
+                  (entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset, total) =>
+                    complete {
+                      if (total) TaxonPhenotypeAnnotation.queryAnnotationsTotal(entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs).map(ResultCount(_))
+                      else TaxonPhenotypeAnnotation.queryAnnotations(entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset)
+                    }
+                }
+              } ~
+              path("annotation" / "sources") { //FIXME needs documentation
+                parameters('taxon.as[IRI], 'phenotype.as[IRI]) {
+                  (taxon, phenotype) =>
+                    complete {
+                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                      TaxonPhenotypeAnnotation.annotationSources(taxon, phenotype)
+                    }
+                }
+              } ~
+              path("with_rank") {
+                parameters('rank.as[IRI], 'in_taxon.as[IRI]) { (rank, inTaxon) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    Taxon.taxaWithRank(rank, inTaxon)
+                  }
+                }
+              } ~
+              path("annotated_taxa_count") {
+                parameter('in_taxon.as[IRI]) { inTaxon =>
+                  complete {
+                    Taxon.countOfAnnotatedTaxa(inTaxon).map(ResultCount(_))
+                  }
+                }
+              } ~
+              path("newick") {
+                parameters('iri.as[IRI]) { (taxon) =>
+                  complete {
+                    Taxon.newickTreeWithRoot(taxon)
+                  }
+                }
+              } ~
+              path("group") {
+                parameters('iri.as[IRI]) { (taxon) =>
+                  complete {
+                    Taxon.commonGroupFor(taxon)
+                  }
+                }
+              } ~
+              pathEnd {
+                parameters('iri.as[IRI]) { iri =>
+                  complete {
+                    Taxon.withIRI(iri)
+                  }
+                }
+              }
+          } ~
+          pathPrefix("entity") {
+            path("search") {
+              parameters('text, 'limit.as[Int].?(20)) { (text, limit) =>
+                complete {
+                  import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                  Term.searchOntologyTerms(text, Uberon, limit)
+                }
+              }
+            } ~
+              pathPrefix("absence") {
+                path("evidence") {
+                  parameters('taxon.as[IRI], 'entity.as[IRI], 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (taxon, entity, limit, offset, totalOnly) =>
+                    complete {
+                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                      if (totalOnly) PresenceAbsenceOfStructure.statesEntailingAbsenceTotal(taxon, entity).map(ResultCount(_))
+                      else PresenceAbsenceOfStructure.statesEntailingAbsence(taxon, entity, limit, offset)
+                    }
+                  }
+                } ~
+                  pathEnd {
+                    parameters('entity.as[IRI], 'in_taxon.as[IRI].?, 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (entity, taxonFilter, limit, offset, totalOnly) =>
+                      complete {
+                        if (totalOnly) PresenceAbsenceOfStructure.taxaExhibitingAbsenceTotal(entity, taxonFilter).map(ResultCount(_))
+                        else PresenceAbsenceOfStructure.taxaExhibitingAbsence(entity, taxonFilter, limit = limit, offset = offset)
+                      }
+                    }
+                  }
+
+              } ~
+              pathPrefix("presence") {
+                path("evidence") {
+                  parameters('taxon.as[IRI], 'entity.as[IRI], 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (taxon, entity, limit, offset, totalOnly) =>
+                    complete {
+                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                      if (totalOnly) PresenceAbsenceOfStructure.statesEntailingPresenceTotal(taxon, entity).map(ResultCount(_))
+                      else PresenceAbsenceOfStructure.statesEntailingPresence(taxon, entity, limit, offset)
+                    }
+                  }
+                } ~
+                  pathEnd {
+                    parameters('entity.as[IRI], 'in_taxon.as[IRI].?, 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (entity, taxonFilter, limit, offset, totalOnly) =>
+                      complete {
+                        if (totalOnly) PresenceAbsenceOfStructure.taxaExhibitingPresenceTotal(entity, taxonFilter).map(ResultCount(_))
+                        else PresenceAbsenceOfStructure.taxaExhibitingPresence(entity, taxonFilter, limit = limit, offset = offset)
+                      }
+                    }
+                  }
+              } ~
+              path("homology") {
+                parameters('entity.as[IRI]) { (entity) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    AnatomicalEntity.homologyAnnotations(entity, false)
+                  }
+                }
+              }
+          } ~
+          pathPrefix("gene") {
+            path("search") {
+              parameters('text, 'taxon.as[IRI].?) { (text, taxonOpt) =>
+                complete {
+                  import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                  Gene.search(text, taxonOpt)
+                }
+              }
+            } ~
+              path("eq") {
+                parameters('id.as[IRI]) { iri =>
+                  complete {
+                    EQForGene.query(iri)
+                  }
+                }
+              } ~
+              path("phenotype_annotations") { // undocumented and not currently used
+                parameters('entity.as[OWLClassExpression].?, 'quality.as[OWLClassExpression].?, 'in_taxon.as[IRI].?, 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) {
+                  (entity, quality, taxonOpt, limit, offset, total) =>
+                    complete {
+                      if (total) GenePhenotypeAnnotation.queryAnnotationsTotal(entity, quality, taxonOpt).map(ResultCount(_))
+                      else GenePhenotypeAnnotation.queryAnnotations(entity, quality, taxonOpt, limit, offset)
+                    }
+                }
+              } ~
+              path("expression_annotations") { // undocumented and not currently used
+                parameters('entity.as[OWLClassExpression].?, 'in_taxon.as[IRI].?, 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) {
+                  (entity, taxonOpt, limit, offset, total) =>
+                    complete {
+                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                      if (total) GeneExpressionAnnotation.queryAnnotationsTotal(entity, taxonOpt).map(ResultCount(_))
+                      else GeneExpressionAnnotation.queryAnnotations(entity, taxonOpt, limit, offset)
+                    }
+                }
+              } ~
+              path("query") { // undocumented and not currently used
+                parameters('entity.as[OWLClassExpression].?(owlThing: OWLClassExpression), 'taxon.as[OWLClassExpression].?(owlThing: OWLClassExpression), 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (entity, taxon, limit, offset, total) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    if (total) Gene.queryTotal(entity, taxon)
+                    else Gene.query(entity, taxon, limit, offset)
+                  }
+                }
+              } ~
+              path("phenotypic_profile") {
+                parameters('iri.as[IRI]) { (iri) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    Gene.phenotypicProfile(iri)
+                  }
+                }
+              } ~
+              path("expression_profile") {
+                parameters('iri.as[IRI]) { (iri) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    Gene.expressionProfile(iri)
+                  }
+                }
+              } ~
+              path("affecting_entity_phenotype") {
+                //TODO update documentation that iri is optional
+                parameters('iri.as[IRI].?, 'quality.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false), 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) {
+                  (iri, quality, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset, total) =>
+                    complete {
+                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                      if (total) Gene.affectingPhenotypeOfEntityTotal(iri, quality, includeParts, includeHistoricalHomologs, includeSerialHomologs).map(ResultCount(_))
+                      else Gene.affectingPhenotypeOfEntity(iri, quality, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset)
+                    }
+                }
+              } ~
+              path("expressed_within_entity") {
+                parameters('iri.as[IRI], 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (iri, limit, offset, total) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    if (total) Gene.expressedWithinEntityTotal(iri).map(ResultCount(_))
+                    else Gene.expressedWithinEntity(iri, limit, offset)
+                  }
+                }
+              } ~
+              path("facet" / "phenotype" / Segment) { facetBy =>
+                parameters('entity.as[IRI].?, 'quality.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false)) {
+                  (entityOpt, qualityOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs) =>
+                    complete {
+                      facetBy match {
+                        case "entity"  => Gene.facetGenesWithPhenotypeByEntity(entityOpt, qualityOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+                        case "quality" => Gene.facetGenesWithPhenotypeByQuality(qualityOpt, entityOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+                      }
+                    }
+                }
+              } ~
+              pathEnd {
+                parameters('iri.as[IRI]) { iri =>
+                  complete {
+                    Gene.withIRI(iri)
+                  }
+                }
+              }
+          } ~
+          pathPrefix("study") {
+            path("query") { //FIXME doc out of date
+              parameters('entity.as[IRI].?, 'quality.as[IRI].?, 'in_taxon.as[IRI].?, 'publication.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false), 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) {
+                (entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset, total) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    if (total) Study.queryStudiesTotal(entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs).map(ResultCount(_))
+                    else Study.queryStudies(entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset)
+                  }
+              }
+            } ~
+              path("facet" / Segment) { facetBy =>
+                parameters('entity.as[IRI].?, 'quality.as[IRI].?, 'in_taxon.as[IRI].?, 'publication.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false)) {
+                  (entityOpt, qualityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs) =>
+                    complete {
+                      facetBy match {
+                        case "entity"  => Study.facetStudiesByEntity(entityOpt, qualityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+                        case "quality" => Study.facetStudiesByQuality(qualityOpt, entityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+                        case "taxon"   => Study.facetStudiesByTaxon(taxonOpt, entityOpt, qualityOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+                      }
+                    }
+                }
+              } ~
+              path("taxa") {
+                parameters('iri.as[IRI], 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (studyIRI, limit, offset, total) =>
+                  complete {
+                    if (total) Study.annotatedTaxaTotal(studyIRI).map(ResultCount(_))
+                    else Study.annotatedTaxa(studyIRI, limit, offset)
+                  }
+                }
+              } ~
+              path("phenotypes") {
+                parameters('iri.as[IRI], 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) { (studyIRI, limit, offset, total) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    if (total) Study.annotatedPhenotypesTotal(studyIRI).map(ResultCount(_))
+                    else Study.annotatedPhenotypes(studyIRI, limit, offset)
+                  }
+                }
+              } ~
+              path("matrix") {
+                parameters('iri.as[IRI]) { (iri) =>
+                  complete {
+                    val prettyPrinter = new scala.xml.PrettyPrinter(9999, 2)
+                    Study.queryMatrix(iri).map(prettyPrinter.format(_))
+                  }
+                }
+              } ~
+              pathEnd {
+                parameters('iri.as[IRI]) { iri =>
+                  complete {
+                    Study.withIRI(iri)
+                  }
+                }
+              }
+          } ~
+          pathPrefix("phenotype") {
+            path("query") {
+              parameters('entity.as[IRI].?, 'quality.as[IRI].?, 'in_taxon.as[IRI].?, 'publication.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false), 'limit.as[Int].?(20), 'offset.as[Int].?(0), 'total.as[Boolean].?(false)) {
+                (entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset, total) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    if (total) Phenotype.queryTaxonPhenotypesTotal(entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs).map(ResultCount(_))
+                    else Phenotype.queryTaxonPhenotypes(entity, quality, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, limit, offset)
+                  }
+              }
+            } ~
+              path("facet" / Segment) { facetBy =>
+                parameters('entity.as[IRI].?, 'quality.as[IRI].?, 'in_taxon.as[IRI].?, 'publication.as[IRI].?, 'parts.as[Boolean].?(false), 'historical_homologs.as[Boolean].?(false), 'serial_homologs.as[Boolean].?(false)) {
+                  (entityOpt, qualityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs) =>
+                    complete {
+                      facetBy match {
+                        case "entity"  => Phenotype.facetPhenotypeByEntity(entityOpt, qualityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+                        case "quality" => Phenotype.facetPhenotypeByQuality(qualityOpt, entityOpt, taxonOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+                        case "taxon"   => Phenotype.facetPhenotypeByTaxon(taxonOpt, entityOpt, qualityOpt, pubOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+                      }
+                    }
+                }
+              } ~
+              path("direct_annotations") { // undocumented and not currently used //FIXME actually this is used in a popup in web UI
+                parameters('iri.as[IRI]) { (iri) =>
+                  complete {
+                    import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                    CharacterDescription.eqAnnotationsForPhenotype(iri)
+                  }
+                }
+              } ~
+              path("nearest_eq") { // undocumented and not currently used
+                parameters('iri.as[IRI]) { (iri) =>
+                  complete {
+                    Phenotype.eqForPhenotype(iri)
+                  }
+                }
+              }
+          } ~
+          pathPrefix("report") {
+            path("data_coverage_figure") { // undocumented and not currently used
+              complete {
+                DataCoverageFigureReport.query()
+              }
+            } ~
+              path("data_coverage_figure_catfish") { // undocumented and not currently used
+                complete {
+                  DataCoverageFigureReportCatfish.query()
+                }
+              } ~
+              path("data_coverage_figure_any_taxon") { // undocumented and not currently used
+                complete {
+                  DataCoverageFigureReportAnyTaxon.query()
+                }
+              }
+          }
+      }
     }
   }
 

--- a/src/main/scala/org/phenoscape/kb/Main.scala
+++ b/src/main/scala/org/phenoscape/kb/Main.scala
@@ -266,6 +266,26 @@ object Main extends HttpApp with App {
                     Similarity.stateSimilarity(leftStudyIRI, leftCharacterNum, leftSymbol, rightStudyIRI, rightCharacterNum, rightSymbol).map(_.toJson)
                   }
                 }
+              } ~
+              path("jaccard") { //FIXME can GET and POST share code better?
+                get {
+                  parameters('iris.as[Seq[String]]) { iriStrings =>
+                    complete {
+                      import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                      val iris = iriStrings.map(IRI.create)
+                      Similarity.pairwiseJaccardSimilarity(iris.toSet)
+                    }
+                  }
+                } ~
+                  post {
+                    formFields('iris.as[Seq[String]]) { iriStrings =>
+                      complete {
+                        import org.phenoscape.kb.Term.JSONResultItemsMarshaller
+                        val iris = iriStrings.map(IRI.create)
+                        Similarity.pairwiseJaccardSimilarity(iris.toSet)
+                      }
+                    }
+                  }
               }
           } ~
           pathPrefix("characterstate") {


### PR DESCRIPTION
Computes Jaccard similarity for #55. Service API is in flux so has not been added to the docs yet. As a followup I will investigate returning raw data so that clients can compute similarity on their own.

Input is an `iris` parameter (in query for GET or as form data for POST) with value that is a JSON array of term URIs.

Endpoint:

`http://kb.phenoscape.org/api/similarity/jaccard`