### PR TITLE
Add ‘phenotype’ parameter to query endpoints. For issue #148.

### DIFF
--- a/src/main/scala/org/phenoscape/kb/Phenotype.scala
+++ b/src/main/scala/org/phenoscape/kb/Phenotype.scala
@@ -60,31 +60,31 @@ object Phenotype {
     }
   }
 
-  def queryTaxonPhenotypes(entity: Option[IRI], quality: QualitySpec, inTaxonOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean, limit: Int = 20, offset: Int = 0): Future[Seq[MinimalTerm]] = for {
-    query <- TaxonPhenotypes.buildQuery(entity, quality, inTaxonOpt, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, false, limit, offset)
+  def queryTaxonPhenotypes(entity: Option[IRI], quality: QualitySpec, inTaxonOpt: Option[IRI], phenotypeOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean, limit: Int = 20, offset: Int = 0): Future[Seq[MinimalTerm]] = for {
+    query <- TaxonPhenotypes.buildQuery(entity, quality, inTaxonOpt, phenotypeOpt, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, false, limit, offset)
     _ = println(query)
     phenotypes <- App.executeSPARQLQueryString(query, fromQueryResult)
   } yield phenotypes
 
-  def queryTaxonPhenotypesTotal(entity: Option[IRI], quality: QualitySpec, inTaxonOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean): Future[Int] = for {
-    query <- TaxonPhenotypes.buildQuery(entity, quality, inTaxonOpt, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, true, 0, 0)
+  def queryTaxonPhenotypesTotal(entity: Option[IRI], quality: QualitySpec, inTaxonOpt: Option[IRI], phenotypeOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean): Future[Int] = for {
+    query <- TaxonPhenotypes.buildQuery(entity, quality, inTaxonOpt, phenotypeOpt, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, true, 0, 0)
     result <- App.executeSPARQLQuery(query)
   } yield ResultCount.count(result)
 
   def facetPhenotypeByEntity(focalEntity: Option[IRI], quality: QualitySpec, inTaxonOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean): Future[List[Facet]] = {
-    val query = (iri: IRI) => queryTaxonPhenotypesTotal(Some(iri), quality, inTaxonOpt, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+    val query = (iri: IRI) => queryTaxonPhenotypesTotal(Some(iri), quality, inTaxonOpt, None, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
     val refine = (iri: IRI) => Term.queryAnatomySubClasses(iri, KBVocab.Uberon, includeParts, includeHistoricalHomologs, includeSerialHomologs).map(_.toSet)
     Facets.facet(focalEntity.getOrElse(KBVocab.entityRoot), query, refine, false)
   }
 
   def facetPhenotypeByQuality(focalQuality: Option[IRI], entity: Option[IRI], inTaxonOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean): Future[List[Facet]] = {
-    val query = (iri: IRI) => queryTaxonPhenotypesTotal(entity, PhenotypicQuality(Some(iri)), inTaxonOpt, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+    val query = (iri: IRI) => queryTaxonPhenotypesTotal(entity, PhenotypicQuality(Some(iri)), inTaxonOpt, None, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
     val refine = (iri: IRI) => Term.querySubClasses(iri, Some(KBVocab.PATO)).map(_.toSet)
     Facets.facet(focalQuality.getOrElse(KBVocab.qualityRoot), query, refine, false)
   }
 
   def facetPhenotypeByTaxon(focalTaxon: Option[IRI], entity: Option[IRI], quality: QualitySpec, publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean): Future[List[Facet]] = {
-    val query = (iri: IRI) => queryTaxonPhenotypesTotal(entity, quality, Some(iri), publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+    val query = (iri: IRI) => queryTaxonPhenotypesTotal(entity, quality, Some(iri), None, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
     val refine = (iri: IRI) => Term.querySubClasses(iri, Some(KBVocab.VTO)).map(_.toSet)
     Facets.facet(focalTaxon.getOrElse(KBVocab.taxonRoot), query, refine, true)
   }

--- a/src/main/scala/org/phenoscape/kb/Study.scala
+++ b/src/main/scala/org/phenoscape/kb/Study.scala
@@ -51,30 +51,30 @@ object Study {
     result.getLiteral("label").getLexicalForm,
     result.getLiteral("citation").getLexicalForm)
 
-  def queryStudies(entity: Option[IRI], quality: QualitySpec, inTaxonOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean, limit: Int = 20, offset: Int = 0): Future[Seq[MinimalTerm]] = for {
-    query <- StudiesRelevantToPhenotype.buildQuery(entity, quality, inTaxonOpt, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, false, limit, offset)
+  def queryStudies(entity: Option[IRI], quality: QualitySpec, inTaxonOpt: Option[IRI], phenotypeOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean, limit: Int = 20, offset: Int = 0): Future[Seq[MinimalTerm]] = for {
+    query <- StudiesRelevantToPhenotype.buildQuery(entity, quality, inTaxonOpt, phenotypeOpt, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, false, limit, offset)
     studies <- App.executeSPARQLQueryString(query, queryToTerm)
   } yield studies
 
-  def queryStudiesTotal(entity: Option[IRI], quality: QualitySpec, inTaxonOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean): Future[Int] = for {
-    query <- StudiesRelevantToPhenotype.buildQuery(entity, quality, inTaxonOpt, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, true, 0, 0)
+  def queryStudiesTotal(entity: Option[IRI], quality: QualitySpec, inTaxonOpt: Option[IRI], phenotypeOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean): Future[Int] = for {
+    query <- StudiesRelevantToPhenotype.buildQuery(entity, quality, inTaxonOpt, phenotypeOpt, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs, true, 0, 0)
     result <- App.executeSPARQLQuery(query)
   } yield ResultCount.count(result)
 
   def facetStudiesByEntity(focalEntity: Option[IRI], quality: QualitySpec, inTaxonOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean): Future[List[Facet]] = {
-    val query = (iri: IRI) => queryStudiesTotal(Some(iri), quality, inTaxonOpt, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+    val query = (iri: IRI) => queryStudiesTotal(Some(iri), quality, inTaxonOpt, None, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
     val refine = (iri: IRI) => Term.queryAnatomySubClasses(iri, KBVocab.Uberon, includeParts, includeHistoricalHomologs, includeSerialHomologs).map(_.toSet)
     Facets.facet(focalEntity.getOrElse(KBVocab.entityRoot), query, refine, false)
   }
 
   def facetStudiesByQuality(focalQuality: Option[IRI], entity: Option[IRI], inTaxonOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean): Future[List[Facet]] = {
-    val query = (iri: IRI) => queryStudiesTotal(entity, PhenotypicQuality(Some(iri)), inTaxonOpt, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+    val query = (iri: IRI) => queryStudiesTotal(entity, PhenotypicQuality(Some(iri)), inTaxonOpt, None, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
     val refine = (iri: IRI) => Term.querySubClasses(iri, Some(KBVocab.PATO)).map(_.toSet)
     Facets.facet(focalQuality.getOrElse(KBVocab.qualityRoot), query, refine, false)
   }
 
   def facetStudiesByTaxon(focalTaxon: Option[IRI], entity: Option[IRI], quality: QualitySpec, publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean): Future[List[Facet]] = {
-    val query = (iri: IRI) => queryStudiesTotal(entity, quality, Some(iri), publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+    val query = (iri: IRI) => queryStudiesTotal(entity, quality, Some(iri), None, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
     val refine = (iri: IRI) => Term.querySubClasses(iri, Some(KBVocab.VTO)).map(_.toSet)
     Facets.facet(focalTaxon.getOrElse(KBVocab.taxonRoot), query, refine, true)
   }

--- a/src/main/scala/org/phenoscape/kb/queries/StudiesRelevantToPhenotype.scala
+++ b/src/main/scala/org/phenoscape/kb/queries/StudiesRelevantToPhenotype.scala
@@ -16,9 +16,9 @@ import scala.concurrent.Future
 
 object StudiesRelevantToPhenotype {
 
-  def buildQuery(entity: Option[IRI], quality: QualitySpec, inTaxon: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean, countOnly: Boolean, limit: Int, offset: Int): Future[String] = {
+  def buildQuery(entity: Option[IRI], quality: QualitySpec, inTaxon: Option[IRI], phenotypeOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean, countOnly: Boolean, limit: Int, offset: Int): Future[String] = {
     for {
-      (whereClause, subqueries) <- constructWhereClause(entity, quality, inTaxon, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+      (whereClause, subqueries) <- constructWhereClause(entity, quality, inTaxon, phenotypeOpt, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
     } yield {
       val unifiedQueries = BlazegraphNamedSubquery.unifyQueries(subqueries)
       val namedQueriesBlock = if (unifiedQueries.nonEmpty) unifiedQueries.map(_.namedQuery).reduce(_ |+| _) else sparql""
@@ -49,7 +49,7 @@ object StudiesRelevantToPhenotype {
   }
 
   //TODO extract common parts with TaxaWithPhenotype
-  private def constructWhereClause(entity: Option[IRI], quality: QualitySpec, inTaxonOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean): Future[(QueryText, Set[BlazegraphNamedSubquery])] = {
+  private def constructWhereClause(entity: Option[IRI], quality: QualitySpec, inTaxonOpt: Option[IRI], phenotypeOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean): Future[(QueryText, Set[BlazegraphNamedSubquery])] = {
     val validHomologyRelation = (if (includeHistoricalHomologs) Set(homologous_to.getIRI) else Set.empty) ++ (if (includeSerialHomologs) Set(serially_homologous_to.getIRI) else Set.empty)
     val homologyQueryPartsFut: ListT[Future, (List[QueryText], Set[BlazegraphNamedSubquery])] = for {
       entityTerm <- entity.toList |> Future.successful |> ListT.apply
@@ -61,12 +61,12 @@ object StudiesRelevantToPhenotype {
     } yield {
       var homComponents = List.empty[QueryText]
       var homSubqueries = Set.empty[BlazegraphNamedSubquery]
-      val homSubquery = TaxaWithPhenotype.phenotypeSubQueryFor(Option(otherEntity), quality, false)
+      val homSubquery = TaxaWithPhenotype.phenotypeSubQueryFor(Option(otherEntity), quality, phenotypeOpt, false)
       val basicHom = coreTaxonToPhenotype(inTaxonOpt.toSet + otherTaxon, publicationOpt, homSubquery)
       homComponents = basicHom :: homComponents
       homSubquery.foreach(q => homSubqueries += q)
       if (includeParts) {
-        val homPartsSubquery = TaxaWithPhenotype.phenotypeSubQueryFor(Option(otherEntity), quality, true)
+        val homPartsSubquery = TaxaWithPhenotype.phenotypeSubQueryFor(Option(otherEntity), quality, phenotypeOpt, true)
         val homParts = coreTaxonToPhenotype(inTaxonOpt.toSet + otherTaxon, publicationOpt, homPartsSubquery)
         homComponents = homParts :: homComponents
         homPartsSubquery.foreach(q => homSubqueries += q)
@@ -80,12 +80,12 @@ object StudiesRelevantToPhenotype {
 
       var components = homologyWhereBlocks.flatten
       var subqueries = homologySubqueries.toSet.flatten
-      val basicSubquery = TaxaWithPhenotype.phenotypeSubQueryFor(entity, quality, false)
+      val basicSubquery = TaxaWithPhenotype.phenotypeSubQueryFor(entity, quality, phenotypeOpt, false)
       val basic = coreTaxonToPhenotype(inTaxonOpt.toSet, publicationOpt, basicSubquery)
       components = basic :: components
       basicSubquery.foreach(q => subqueries += q)
       if (includeParts) {
-        val partsSubquery = TaxaWithPhenotype.phenotypeSubQueryFor(entity, quality, true)
+        val partsSubquery = TaxaWithPhenotype.phenotypeSubQueryFor(entity, quality, phenotypeOpt, true)
         val parts = coreTaxonToPhenotype(inTaxonOpt.toSet, publicationOpt, partsSubquery)
         components = parts :: components
         partsSubquery.foreach(q => subqueries += q)

--- a/src/main/scala/org/phenoscape/kb/queries/TaxonAnnotations.scala
+++ b/src/main/scala/org/phenoscape/kb/queries/TaxonAnnotations.scala
@@ -18,9 +18,9 @@ import scala.language.postfixOps
 
 object TaxonAnnotations {
 
-  def buildQuery(entity: Option[IRI], quality: QualitySpec, inTaxon: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean, countOnly: Boolean, limit: Int, offset: Int): Future[String] = {
+  def buildQuery(entity: Option[IRI], quality: QualitySpec, inTaxon: Option[IRI], phenotypeOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean, countOnly: Boolean, limit: Int, offset: Int): Future[String] = {
     for {
-      (whereClause, subqueries) <- constructWhereClause(entity, quality, inTaxon, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
+      (whereClause, subqueries) <- constructWhereClause(entity, quality, inTaxon, phenotypeOpt, publicationOpt, includeParts, includeHistoricalHomologs, includeSerialHomologs)
     } yield {
       val unifiedQueries = BlazegraphNamedSubquery.unifyQueries(subqueries)
       val namedQueriesBlock = if (unifiedQueries.nonEmpty) unifiedQueries.map(_.namedQuery).reduce(_ |+| _) else sparql""
@@ -51,7 +51,7 @@ object TaxonAnnotations {
   }
 
   //TODO extract common parts with TaxaWithPhenotype
-  private def constructWhereClause(entity: Option[IRI], quality: QualitySpec, inTaxonOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean): Future[(QueryText, Set[BlazegraphNamedSubquery])] = {
+  private def constructWhereClause(entity: Option[IRI], quality: QualitySpec, inTaxonOpt: Option[IRI], phenotypeOpt: Option[IRI], publicationOpt: Option[IRI], includeParts: Boolean, includeHistoricalHomologs: Boolean, includeSerialHomologs: Boolean): Future[(QueryText, Set[BlazegraphNamedSubquery])] = {
     val validHomologyRelation = (if (includeHistoricalHomologs) Set(homologous_to.getIRI) else Set.empty) ++ (if (includeSerialHomologs) Set(serially_homologous_to.getIRI) else Set.empty)
     val homologyQueryPartsFut: ListT[Future, (List[QueryText], Set[BlazegraphNamedSubquery])] = for {
       entityTerm <- entity.toList |> Future.successful |> ListT.apply
@@ -63,12 +63,12 @@ object TaxonAnnotations {
     } yield {
       var homComponents = List.empty[QueryText]
       var homSubqueries = Set.empty[BlazegraphNamedSubquery]
-      val homSubquery = TaxaWithPhenotype.phenotypeSubQueryFor(Option(otherEntity), quality, false)
+      val homSubquery = TaxaWithPhenotype.phenotypeSubQueryFor(Option(otherEntity), quality, phenotypeOpt, false)
       val basicHom = coreTaxonToPhenotype(inTaxonOpt.toSet + otherTaxon, publicationOpt, homSubquery)
       homComponents = basicHom :: homComponents
       homSubquery.foreach(q => homSubqueries += q)
       if (includeParts) {
-        val homPartsSubquery = TaxaWithPhenotype.phenotypeSubQueryFor(Option(otherEntity), quality, true)
+        val homPartsSubquery = TaxaWithPhenotype.phenotypeSubQueryFor(Option(otherEntity), quality, phenotypeOpt, true)
         val homParts = coreTaxonToPhenotype(inTaxonOpt.toSet + otherTaxon, publicationOpt, homPartsSubquery)
         homComponents = homParts :: homComponents
         homPartsSubquery.foreach(q => homSubqueries += q)
@@ -82,12 +82,12 @@ object TaxonAnnotations {
 
       var components = homologyWhereBlocks.flatten
       var subqueries = homologySubqueries.toSet.flatten
-      val basicSubquery = TaxaWithPhenotype.phenotypeSubQueryFor(entity, quality, false)
+      val basicSubquery = TaxaWithPhenotype.phenotypeSubQueryFor(entity, quality, phenotypeOpt, false)
       val basic = coreTaxonToPhenotype(inTaxonOpt.toSet, publicationOpt, basicSubquery)
       components = basic :: components
       basicSubquery.foreach(q => subqueries += q)
       if (includeParts) {
-        val partsSubquery = TaxaWithPhenotype.phenotypeSubQueryFor(entity, quality, true)
+        val partsSubquery = TaxaWithPhenotype.phenotypeSubQueryFor(entity, quality, phenotypeOpt, true)
         val parts = coreTaxonToPhenotype(inTaxonOpt.toSet, publicationOpt, partsSubquery)
         components = parts :: components
         partsSubquery.foreach(q => subqueries += q)

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1340,6 +1340,12 @@ paths:
           required: false
           type: string
           format: IRI
+        - name: phenotype
+          in: query
+          description: A phenotype term which must subsume the matched annotations
+          required: false
+          type: string
+          format: IRI
         - name: publication
           in: query
           description: A publication IRI to limit the results
@@ -1419,6 +1425,12 @@ paths:
         - name: in_taxon
           in: query
           description: A taxon group to limit the results
+          required: false
+          type: string
+          format: IRI
+        - name: phenotype
+          in: query
+          description: A phenotype term which must subsume the matched annotations
           required: false
           type: string
           format: IRI
@@ -1565,6 +1577,12 @@ paths:
           description: Quality class expression in [OWL Manchester syntax](http://www.w3.org/TR/owl2-manchester-syntax/)
           required: false
           type: string
+        - name: phenotype
+          in: query
+          description: A phenotype term which must subsume the matched annotations
+          required: false
+          type: string
+          format: IRI
         - name: parts
           in: query
           description: whether to include parts of the entity in the query
@@ -1665,6 +1683,12 @@ paths:
         - name: in_taxon
           in: query
           description: A taxon group IRI to limit the results
+          required: false
+          type: string
+          format: IRI
+        - name: phenotype
+          in: query
+          description: A phenotype term which must subsume the matched annotations
           required: false
           type: string
           format: IRI
@@ -2074,6 +2098,12 @@ paths:
         - name: in_taxon
           in: query
           description: A taxon group to limit the results
+          required: false
+          type: string
+          format: IRI
+        - name: phenotype
+          in: query
+          description: A phenotype term which must subsume the matched annotations
           required: false
           type: string
           format: IRI


### PR DESCRIPTION
This adds a 'phenotype' parameter to:

- /taxon/phenotypes
- /taxon/with_phenotype
- /taxon/annotations
- /study/query
- /phenotype/query
