### PR TITLE
Don’t return owl:Thing in ancestor results.

### DIFF
--- a/src/main/scala/org/phenoscape/kb/Graph.scala
+++ b/src/main/scala/org/phenoscape/kb/Graph.scala
@@ -10,6 +10,7 @@ import org.phenoscape.owlet.SPARQLComposer._
 import org.phenoscape.sparql.SPARQLInterpolation._
 import org.phenoscape.sparql.SPARQLInterpolation.QueryText
 import org.phenoscape.kb.util.SPARQLInterpolatorOWLAPI._
+import org.phenoscape.scowl
 import org.phenoscape.sparql.SPARQLInterpolationOWL._
 import org.semanticweb.owlapi.model.IRI
 
@@ -57,6 +58,7 @@ object Graph {
        WHERE {
          VALUES ?term { $valuesElements }
          ?term $rdfsSubClassOf ?ancestor .
+         FILTER(?ancestor != $owlThing)
        }
           """
       val futurePairs = App.executeSPARQLQueryString(query.text,

--- a/src/main/scala/org/phenoscape/kb/Similarity.scala
+++ b/src/main/scala/org/phenoscape/kb/Similarity.scala
@@ -261,6 +261,7 @@ object Similarity {
               FROM $KBClosureGraph
               WHERE {
                 $iri $rdfsSubClassOf ?subsumer .
+                FILTER(?subsumer != $owlThing)
               }
             """
     App.executeSPARQLQueryString(query.text, qs => IRI.create(qs.getResource("subsumer").getURI)).map(_.toSet)
@@ -285,6 +286,7 @@ object Similarity {
     App.executeSPARQLQueryString(query.text, qs => IRI.create(qs.getResource("subsumer").getURI)).map(_.toSet)
   }
 
+  
   def frequency(terms: Set[IRI], corpus: IRI): Future[TermFrequencyTable] = {
     import scalaz.Scalaz._
     val values = if (terms.nonEmpty) terms.map(t => sparql" $t ").reduce(_ + _) else sparql""

--- a/src/main/scala/org/phenoscape/kb/Term.scala
+++ b/src/main/scala/org/phenoscape/kb/Term.scala
@@ -278,6 +278,7 @@ object Term {
             GRAPH $KBClosureGraph {
               $iri $rdfsSubClassOf ?term .
               FILTER($iri != ?term)
+              FILTER(?term != $owlThing)
             }
             """
     val partOfs =
@@ -286,6 +287,7 @@ object Term {
             GRAPH $KBClosureGraph {
               $iri $rdfsSubClassOf ?container .
               FILTER($iri != ?container)
+              FILTER(?container != $owlThing)
             }
             """
     val all = if (includePartOf) sparql" { $superclasses } UNION { $partOfs } " else superclasses
@@ -308,6 +310,7 @@ object Term {
             GRAPH $KBClosureGraph {
               ?term $rdfsSubClassOf $iri .
               FILTER($iri != ?term)
+              FILTER(?term != $owlThing)
             }
             """
     val parts =


### PR DESCRIPTION
This addresses much of the problem identified in #382. However it doesn't yet change the response issued when a frequency is requested for owl:Thing.