### PR TITLE
Support search and info for genes without phenotype annotations in switch to Monarch data.

### DIFF
--- a/src/main/scala/org/phenoscape/kb/KBVocab.scala
+++ b/src/main/scala/org/phenoscape/kb/KBVocab.scala
@@ -67,5 +67,10 @@ object KBVocab {
   val InferredAbsence = IRI.create("http://purl.org/phenoscape/vocab.owl#inferred_absence")
 
   val AnnotatedGene = IRI.create("http://purl.org/phenoscape/vocab.owl#AnnotatedGene")
+  val Pseudogene = IRI.create("http://purl.obolibrary.org/obo/SO_0000336")
+  val ProteinCodingGene = IRI.create("http://purl.obolibrary.org/obo/SO_0001217")
+  val lincRNA_gene = IRI.create("http://purl.obolibrary.org/obo/SO_0001641")
+  val lncRNA_gene = IRI.create("http://purl.obolibrary.org/obo/SO_0002127")
+  val miRNA_gene = IRI.create("http://purl.obolibrary.org/obo/SO_0001265")
 
 }

--- a/src/main/scala/org/phenoscape/kb/Main.scala
+++ b/src/main/scala/org/phenoscape/kb/Main.scala
@@ -79,10 +79,9 @@ object Main extends HttpApp with App {
             case a: JsArray => a.elements.map(_.convertTo[String])
             case _          => throw new IllegalArgumentException(s"Not a valid JSON array: $text")
           }
-        }.recoverWith {
-          case NonFatal(_) =>
-            // must throw this particular exception for the Unmarshaller to fail over to the next
-            Try(throw new Unmarshaller.UnsupportedContentTypeException(Set(MediaTypes.`application/json`)))
+        }.recoverWith { case NonFatal(_) =>
+          // must throw this particular exception for the Unmarshaller to fail over to the next
+          Try(throw new Unmarshaller.UnsupportedContentTypeException(Set(MediaTypes.`application/json`)))
         }
       })
 
@@ -1009,10 +1008,10 @@ object Main extends HttpApp with App {
               } ~
               pathPrefix("gene") {
                 path("search") {
-                  parameters('text, 'taxon.as[IRI].?) { (text, taxonOpt) => //FIXME add limit option?
+                  parameters('text, 'taxon.as[IRI].?, 'limit.as[Int].?(100)) { (text, taxonOpt, limit) =>
                     complete {
                       import org.phenoscape.kb.JSONResultItem.JSONResultItemsMarshaller
-                      Gene.search(text, taxonOpt)
+                      Gene.search(text, taxonOpt, if (limit < 1) None else Some(limit))
                     }
                   }
                 } ~

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1961,7 +1961,7 @@ paths:
           format: IRI
         - name: limit
           in: query
-          description: maximum results to return
+          description: maximum results to return; returns all results for limit=0
           required: false
           type: integer
           default: 100

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1959,6 +1959,12 @@ paths:
           required: false
           type: string
           format: IRI
+        - name: limit
+          in: query
+          description: maximum results to return
+          required: false
+          type: integer
+          default: 100
       responses:
         200:
           description: gene matches


### PR DESCRIPTION
Fixes #398 